### PR TITLE
RUNNING bash command to get java-17 and nextflow installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -370,3 +370,13 @@ RUN set -ex \
   apt-get install -y --no-install-recommends \
     r-base \
   && Rscript -e 'install.packages(c("survival", "optparse"), repos="https://cloud.r-project.org")'
+
+# Add java/jre-17 installation, and install local on /usr/bin/local
+RUN set -eux; \
+        apt-get update; \
+        apt-get install -y --no-install-recommends \
+          openjdk-17-jre-headless; \
+        apt-get -y install curl \
+        && curl -s https://get.nextflow.io | bash \
+        && chmod +x nextflow \
+        && mv nextflow /usr/local/bin


### PR DESCRIPTION
Adding another RUN in the Dockerfile to get java-jre 17 and Nextflow within the image
This will ease further work on the user end when update the manual.
Likewise, we avoid the user having to install the right version of Java as well as Nextflow themselves